### PR TITLE
Added exact character count validation

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -15,6 +15,8 @@
     <attr name="errorColor" format="color"/>
     <!-- characters count limit. 0 means no limit. -->
     <attr name="maxCharacters" format="integer"/>
+    <!-- characters count should be exactly this value. 0 means no limit. -->
+    <attr name="exactCharacters" format="integer"/>
     <!-- whether to show the bottom ellipsis in singleLine mode -->
     <attr name="singleLineEllipsis" format="boolean"/>
   </declare-styleable>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -219,6 +219,27 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
+        android:text="Exact Character Count:"
+        android:textColor="#333333"
+        android:textSize="14sp"/>
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="app:exactCharacters=&quot;10&quot;"
+        android:textColor="#888888"
+        android:textSize="14sp"/>
+
+      <com.rengwuxian.materialedittext.MaterialEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Exact Characters"
+        app:exactCharacters="10"/>
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:text="Max Characters With Custom Error Color:"
         android:textColor="#333333"
         android:textSize="14sp"/>


### PR DESCRIPTION
EditText is valid if and only if its text' length is equal to `exactCharacters`.

Works just like `maxCharacters` validation, but has greater priority (if `exactCharacters` is set, then `maxCharacters` is not validated). I added an example to the sample project as well.
