### PR TITLE
Returning error message set via setError() when calling getError()

### DIFF
--- a/library/src/androidTest/java/com/rengwuxian/materialedittext/MaterialEditTextSetErrorTest.java
+++ b/library/src/androidTest/java/com/rengwuxian/materialedittext/MaterialEditTextSetErrorTest.java
@@ -1,0 +1,28 @@
+package com.rengwuxian.materialedittext;
+
+import android.test.AndroidTestCase;
+
+/**
+ * Tests setting and getting the error message from a {@link com.rengwuxian.materialedittext.MaterialEditText}.
+ * <p/>
+ * Created by egor on 25/11/14.
+ */
+public class MaterialEditTextSetErrorTest extends AndroidTestCase {
+
+    private MaterialEditText editTextUnderTest;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        editTextUnderTest = new MaterialEditText(getContext());
+    }
+
+    public void testGetErrorReturnsNullIfNoErrorMessageWasSet() {
+        assertNull(editTextUnderTest.getError());
+    }
+
+    public void testGetErrorReturnsMessageSetEarlierViaSetError() {
+        editTextUnderTest.setError("Error!");
+        assertEquals("Error!", editTextUnderTest.getError().toString());
+    }
+}

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -416,7 +416,12 @@ public class MaterialEditText extends EditText {
 		postInvalidate();
 	}
 
-	/**
+    @Override
+    public CharSequence getError() {
+        return tempErrorText;
+    }
+
+    /**
 	 * if {@link #extendBottom} is false, set it true and reset the paddings.
 	 */
 	private void extendBottom() {


### PR DESCRIPTION
I had some tests in my project which were checking if the error message has been set using getError(). Apparently, the method wasn't implemented, so I added it along with a small unit test to verify the fix. 
