### PR TITLE
Use IntDef for float label modes to have lint and better IDE autocomplete support

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.Editable;
@@ -32,6 +33,9 @@ import java.util.regex.Pattern;
  * <p/>
  */
 public class MaterialAutoCompleteTextView extends AutoCompleteTextView {
+
+  @IntDef({FLOATING_LABEL_NONE, FLOATING_LABEL_NORMAL, FLOATING_LABEL_HIGHLIGHT})
+  public @interface FloatingLabelType {}
   public static final int FLOATING_LABEL_NONE = 0;
   public static final int FLOATING_LABEL_NORMAL = 1;
   public static final int FLOATING_LABEL_HIGHLIGHT = 2;
@@ -421,7 +425,7 @@ public class MaterialAutoCompleteTextView extends AutoCompleteTextView {
     }
   }
 
-  public void setFloatingLabel(int mode) {
+  public void setFloatingLabel(@FloatingLabelType int mode) {
     setFloatingLabelInternal(mode);
     postInvalidate();
   }

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -8,6 +8,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.Editable;
@@ -32,6 +33,9 @@ import java.util.regex.Pattern;
  * <p/>
  */
 public class MaterialEditText extends EditText {
+
+  @IntDef({FLOATING_LABEL_NONE, FLOATING_LABEL_NORMAL, FLOATING_LABEL_HIGHLIGHT})
+  public @interface FloatingLabelType {}
   public static final int FLOATING_LABEL_NONE = 0;
   public static final int FLOATING_LABEL_NORMAL = 1;
   public static final int FLOATING_LABEL_HIGHLIGHT = 2;
@@ -420,7 +424,7 @@ public class MaterialEditText extends EditText {
     }
   }
 
-  public void setFloatingLabel(int mode) {
+  public void setFloatingLabel(@FloatingLabelType int mode) {
     setFloatingLabelInternal(mode);
     postInvalidate();
   }


### PR DESCRIPTION
One more pull request :)

Since the library uses android's annotations support library, you can take advantage of `IntDef` to better lint floating label modes. Users' IDEs will recognize this annotation and offer to autocomplete with them and also show an error lint if they don't pass in one of the predefined modes. Similar to how `Toast` requires `Toast.LENGTH_SHORT` or `Toast.LENGTH_LONG` even though they're just ints.

![screenshot 2014-11-26 00 46 54](https://cloud.githubusercontent.com/assets/1361086/5198465/334cb6a4-7506-11e4-8e38-b8d50b8da2db.png)
