### PR TITLE
Update some documentation and add a setter for errorMessage

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/validation/METValidator.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/validation/METValidator.java
@@ -7,10 +7,20 @@ import android.support.annotation.NonNull;
  */
 public abstract class METValidator {
 
+  /**
+   * Error message that the view will display if validation fails.
+   *
+   * This is protected, so you can change this dynamically in your {@link #isValid(CharSequence, boolean)}
+   * implementation. If necessary, you can also interact with this via its getter and setter.
+   */
   protected String errorMessage;
 
   public METValidator(@NonNull String errorMessage) {
       this.errorMessage = errorMessage;
+  }
+
+  public void setErrorMessage(@NonNull String errorMessage) {
+    this.errorMessage = errorMessage;
   }
 
   @NonNull


### PR DESCRIPTION
In #29 I made the `errorMessage` field protected with the intention of allowing it to be easily changed in the isValid implementation, but it's not very obvious at the moment :frowning:. This also allows it to be set externally if necessary.
