### PR TITLE
fix error animator so it doesn't bounce

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -986,7 +986,6 @@ public class MaterialEditText extends EditText {
     if (bottomLinesAnimator == null) {
       bottomLinesAnimator = ObjectAnimator.ofFloat(this, "currentBottomLines", destBottomLines);
     } else {
-      bottomLinesAnimator.end();
       bottomLinesAnimator.setFloatValues(destBottomLines);
     }
     return bottomLinesAnimator;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,6 +20,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'com.rengwuxian.materialedittext:library:1.8.1'
-//    compile project(':library')
+//    compile 'com.rengwuxian.materialedittext:library:1.8.1'
+    compile project(':library')
 }

--- a/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
+++ b/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
@@ -2,6 +2,8 @@ package com.rengwuxian.materialedittext.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -44,6 +46,18 @@ public class MainActivity extends ActionBarActivity {
 	}
 
 	private void initSetErrorEt() {
+		final EditText title = (EditText) findViewById(R.id.title);
+		title.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) { }
+			@Override
+			public void afterTextChanged(Editable s) {
+				title.setError(s.length() < 8 ? "Too short!" : null);
+			}
+		});
+
 		final EditText bottomTextEt = (EditText) findViewById(R.id.bottomTextEt);
 		final Button setErrorBt = (Button) findViewById(R.id.setErrorBt);
 		setErrorBt.setOnClickListener(new View.OnClickListener() {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -22,6 +22,7 @@
 			android:paddingTop="16dp">
 
 			<com.rengwuxian.materialedittext.MaterialEditText
+				android:id="@+id/title"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:hint="Library Name"
@@ -30,9 +31,7 @@
 				android:textSize="34sp"
 				app:baseColor="@android:color/white"
 				app:floatingLabel="highlight"
-				app:maxCharacters="20"
-				app:primaryColor="?colorAccent"
-				app:singleLineEllipsis="true"/>
+				app:primaryColor="?colorAccent"/>
 
 			<com.rengwuxian.materialedittext.MaterialEditText
 				android:layout_width="match_parent"


### PR DESCRIPTION
The main change is just removing `bottomLinesAnimator.end();`

The change to the example is just to reproduce so you can see the difference. If you keep the line `bottomLinesAnimator.end();` and try the new example, you'll see the title layouts bounce as you go below 8 characters as the animator thrashes.