### PR TITLE
Fix #53 - Invalid size when updating bottom lines.

### DIFF
--- a/library/src/androidTest/java/com/rengwuxian/materialedittext/MaterialEditTextTest.java
+++ b/library/src/androidTest/java/com/rengwuxian/materialedittext/MaterialEditTextTest.java
@@ -3,11 +3,11 @@ package com.rengwuxian.materialedittext;
 import android.test.AndroidTestCase;
 
 /**
- * Tests setting and getting the error message from a {@link com.rengwuxian.materialedittext.MaterialEditText}.
+ * Misc tests for {@link com.rengwuxian.materialedittext.MaterialEditText}.
  * <p/>
  * Created by egor on 25/11/14.
  */
-public class MaterialEditTextSetErrorTest extends AndroidTestCase {
+public class MaterialEditTextTest extends AndroidTestCase {
 
     private MaterialEditText editTextUnderTest;
 
@@ -22,7 +22,12 @@ public class MaterialEditTextSetErrorTest extends AndroidTestCase {
     }
 
     public void testGetErrorReturnsMessageSetEarlierViaSetError() {
+        editTextUnderTest.layout(0, 0, 1000, 1000);
         editTextUnderTest.setError("Error!");
         assertEquals("Error!", editTextUnderTest.getError().toString());
+    }
+
+    public void testSetErrorWithZeroSizeDoesNotThrow() {
+        editTextUnderTest.setError("Error!");
     }
 }

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -626,24 +626,31 @@ public class MaterialEditText extends EditText {
     }
   }
 
-  private void adjustBottomLines() {
-    // adjust bottom lines
-    int destBottomLines;
-    textPaint.setTextSize(bottomTextSize);
-    if (tempErrorText != null) {
-      textLayout = new StaticLayout(tempErrorText, textPaint, getMeasuredWidth() - getBottomTextLeftOffset() - getBottomTextRightOffset() - getPaddingLeft() - getPaddingRight(), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, true);
-      destBottomLines = Math.max(textLayout.getLineCount(), minBottomTextLines);
-    } else if (helperText != null) {
-      textLayout = new StaticLayout(helperText, textPaint, getMeasuredWidth() - getBottomTextLeftOffset() - getBottomTextRightOffset() - getPaddingLeft() - getPaddingRight(), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, true);
-      destBottomLines = Math.max(textLayout.getLineCount(), minBottomTextLines);
-    } else {
-      destBottomLines = minBottomLines;
+    /**
+     * @return True, if adjustments were made that require the view to be invalidated.
+     */
+    private boolean adjustBottomLines() {
+      // Bail out if we have a zero width; lines will be adjusted during next layout.
+      if (getWidth() == 0) {
+        return false;
+      }
+      int destBottomLines;
+      textPaint.setTextSize(bottomTextSize);
+      if (tempErrorText != null) {
+        textLayout = new StaticLayout(tempErrorText, textPaint, getWidth() - getBottomTextLeftOffset() - getBottomTextRightOffset() - getPaddingLeft() - getPaddingRight(), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, true);
+        destBottomLines = Math.max(textLayout.getLineCount(), minBottomTextLines);
+      } else if (helperText != null) {
+        textLayout = new StaticLayout(helperText, textPaint, getWidth() - getBottomTextLeftOffset() - getBottomTextRightOffset() - getPaddingLeft() - getPaddingRight(), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, true);
+        destBottomLines = Math.max(textLayout.getLineCount(), minBottomTextLines);
+      } else {
+        destBottomLines = minBottomLines;
+      }
+      if (bottomLines != destBottomLines) {
+        getBottomLinesAnimator(destBottomLines).start();
+      }
+      bottomLines = destBottomLines;
+      return true;
     }
-    if (bottomLines != destBottomLines) {
-      getBottomLinesAnimator(destBottomLines).start();
-    }
-    bottomLines = destBottomLines;
-  }
 
   /**
    * get inner top padding, not the real paddingTop
@@ -823,8 +830,9 @@ public class MaterialEditText extends EditText {
 
   public void setHelperText(CharSequence helperText) {
     this.helperText = helperText == null ? null : helperText.toString();
-    adjustBottomLines();
-    postInvalidate();
+    if (adjustBottomLines()) {
+      postInvalidate();
+    }
   }
 
   public String getHelperText() {
@@ -843,8 +851,9 @@ public class MaterialEditText extends EditText {
   @Override
   public void setError(CharSequence errorText) {
     tempErrorText = errorText == null ? null : errorText.toString();
-    adjustBottomLines();
-    postInvalidate();
+    if (adjustBottomLines()) {
+      postInvalidate();
+    }
   }
 
   @Override

--- a/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
+++ b/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
@@ -21,6 +21,7 @@ public class MainActivity extends ActionBarActivity {
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 		getSupportActionBar().setDisplayShowTitleEnabled(false);
 		initEnableBt();
+    initGoneEt();
 		initSingleLineEllipsisEt();
 		initSetErrorEt();
 		initValidationEt();
@@ -37,6 +38,21 @@ public class MainActivity extends ActionBarActivity {
 			}
 		});
 	}
+  private void initGoneEt() {
+    final EditText goneEt = (EditText) findViewById(R.id.goneEt);
+    goneEt.setError("I was hidden from view!");
+    final Button toggleGoneButton = (Button) findViewById(R.id.toggleGoneBt);
+    toggleGoneButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        if (goneEt.getVisibility() == View.GONE) {
+          goneEt.setVisibility(View.VISIBLE);
+        } else {
+          goneEt.setVisibility(View.GONE);
+        }
+      }
+    });
+  }
 
 	private void initSingleLineEllipsisEt() {
 		EditText singleLineEllipsisEt = (EditText) findViewById(R.id.singleLineEllipsisEt);

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -84,6 +84,30 @@
 
 			</LinearLayout>
 
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.rengwuxian.materialedittext.MaterialEditText
+                    android:id="@+id/goneEt"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_toLeftOf="@+id/toggleGoneBt"
+                    android:visibility="gone"
+                    android:hint="Gone"/>
+
+                <Button
+                    android:id="@+id/toggleGoneBt"
+                    android:layout_width="100dp"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_marginLeft="8dp"
+                    android:text="TOGGLE GONE"/>
+                
+            </RelativeLayout>
+
 			<TextView
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"


### PR DESCRIPTION
`adjustBottomLines()` was not checking for valid dimensions when
creating a StaticLayout, causing an InvalidParameterException to be
thrown. This is likely to be the case when when calling `setError()`
on a view before it's been laid out. This fix simply no-ops the
adjustment if the view has a zero size, and waits for the next layout
pass to trigger another attempt.

A case that's not handled here is when the view has a non-zero size,
but is still too small to show the views. For now, I've left this as a
crashing case, as I figure it's desirable for the user to know that
they've over-constrained the view, rather than it fallback to only
partially functioning.