### PR TITLE
Added setSelection to make the cursor point to end of the text

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
@@ -449,6 +449,7 @@ public class MaterialAutoCompleteTextView extends AutoCompleteTextView {
         setHintTextColor(baseColor & 0x00ffffff | 0x44000000);
       }
       setText(text);
+      setSelection(text.length());
       floatingLabelFraction = 1;
       floatingLabelShown = true;
     } else {

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -449,6 +449,7 @@ public class MaterialEditText extends EditText {
         setHintTextColor(baseColor & 0x00ffffff | 0x44000000);
       }
       setText(text);
+      setSelection(text.length());
       floatingLabelFraction = 1;
       floatingLabelShown = true;
     } else {

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialMultiAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialMultiAutoCompleteTextView.java
@@ -446,6 +446,7 @@ public class MaterialMultiAutoCompleteTextView extends MultiAutoCompleteTextView
         setHintTextColor(baseColor & 0x00ffffff | 0x44000000);
       }
       setText(text);
+      setSelection(text.length());
       floatingLabelFraction = 1;
       floatingLabelShown = true;
     } else {


### PR DESCRIPTION
The cursor of default EditText point to the end of the text. Made the cursor of MaterialEditText point to end of the text.