### PR TITLE
MaterialEditText: Prevented initialisation in Developer Previews

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -332,6 +332,10 @@ public class MaterialEditText extends AppCompatEditText {
   }
 
   private void init(Context context, AttributeSet attrs) {
+    if (isInEditMode()) {
+        return;
+    }
+
     iconSize = getPixel(32);
     iconOuterWidth = getPixel(48);
     iconOuterHeight = getPixel(32);


### PR DESCRIPTION
Solved #178 very basically by preventing initialisation in edit mode.

A further step would be to try to mimick the actual rendering with dummy data in the display mode, by setting those before the **return** line 335..