### PR TITLE
Fixed clear button isn't clickable issue when inputting long single line text

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -1504,8 +1504,8 @@ public class MaterialEditText extends AppCompatEditText {
   private boolean insideClearButton(MotionEvent event) {
     float x = event.getX();
     float y = event.getY();
-    int startX = getScrollX() + (iconLeftBitmaps == null ? 0 : (iconOuterWidth + iconPadding));
-    int endX = getScrollX() + (iconRightBitmaps == null ? getWidth() : getWidth() - iconOuterWidth - iconPadding);
+    int startX = iconLeftBitmaps == null ? 0 : (iconOuterWidth + iconPadding);
+    int endX = iconRightBitmaps == null ? getWidth() : getWidth() - iconOuterWidth - iconPadding;
     int buttonLeft;
     if (isRTL()) {
       buttonLeft = startX;


### PR DESCRIPTION

Steps to reproduce the issue:
1. set android:singleLine="true"
2. input very long text in the edittext field
3. the clear button wouldn't work.

The fix has been tested on right-to-left language as well.
