### PR TITLE
Added support for pre-compiled patterns in RegexpValidator

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/validation/RegexpValidator.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/validation/RegexpValidator.java
@@ -16,6 +16,11 @@ public class RegexpValidator extends METValidator {
     pattern = Pattern.compile(regex);
   }
 
+  public RegexpValidator(@NonNull String errorMessage, @NonNull Pattern pattern) {
+    super(errorMessage);
+    this.pattern = pattern;
+  }
+
   @Override
   public boolean isValid(@NonNull CharSequence text, boolean isEmpty) {
     return pattern.matcher(text).matches();


### PR DESCRIPTION
Added support for pre-compiled patterns to RegexpValidator.

Some common regular expressions come pre-compiled in android, see: http://developer.android.com/reference/android/util/Patterns.html

