### PR TITLE
Fix clear button not work while inputted text length exceed screen

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -1504,8 +1504,8 @@ public class MaterialEditText extends AppCompatEditText {
   private boolean insideClearButton(MotionEvent event) {
     float x = event.getX();
     float y = event.getY();
-    int startX = getScrollX() + (iconLeftBitmaps == null ? 0 : (iconOuterWidth + iconPadding));
-    int endX = getScrollX() + (iconRightBitmaps == null ? getWidth() : getWidth() - iconOuterWidth - iconPadding);
+    int startX = iconLeftBitmaps == null ? 0 : (iconOuterWidth + iconPadding);
+    int endX = iconRightBitmaps == null ? getWidth() : getWidth() - iconOuterWidth - iconPadding;
     int buttonLeft;
     if (isRTL()) {
       buttonLeft = startX;


### PR DESCRIPTION
This fixes handling of clear button not work in long text situation. 