### PR TITLE
Clear button would not be shown if the EditText is disabled

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
@@ -1291,7 +1291,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     }
 
     // draw the clear button
-    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText())) {
+    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText()) && isEnabled()) {
       paint.setAlpha(255);
       int buttonLeft;
       if (isRTL()) {
@@ -1463,7 +1463,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
       setSelection(0);
       return false;
     }
-    if (hasFocus() && showClearButton) {
+    if (hasFocus() && showClearButton && isEnabled()) {
       switch (event.getAction()) {
         case MotionEvent.ACTION_DOWN:
           if (insideClearButton(event)) {

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -1291,7 +1291,7 @@ public class MaterialEditText extends AppCompatEditText {
     }
 
     // draw the clear button
-    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText())) {
+    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText()) && isEnabled()) {
       paint.setAlpha(255);
       int buttonLeft;
       if (isRTL()) {
@@ -1463,7 +1463,7 @@ public class MaterialEditText extends AppCompatEditText {
       setSelection(0);
       return false;
     }
-    if (hasFocus() && showClearButton) {
+    if (hasFocus() && showClearButton && isEnabled()) {
       switch (event.getAction()) {
         case MotionEvent.ACTION_DOWN:
           if (insideClearButton(event)) {

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialMultiAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialMultiAutoCompleteTextView.java
@@ -1288,7 +1288,7 @@ public class MaterialMultiAutoCompleteTextView extends AppCompatMultiAutoComplet
     }
 
     // draw the clear button
-    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText())) {
+    if (hasFocus() && showClearButton && !TextUtils.isEmpty(getText()) && isEnabled()) {
       paint.setAlpha(255);
       int buttonLeft;
       if (isRTL()) {
@@ -1460,7 +1460,7 @@ public class MaterialMultiAutoCompleteTextView extends AppCompatMultiAutoComplet
       setSelection(0);
       return false;
     }
-    if (hasFocus() && showClearButton) {
+    if (hasFocus() && showClearButton && isEnabled()) {
       switch (event.getAction()) {
         case MotionEvent.ACTION_DOWN:
           if (insideClearButton(event)) {


### PR DESCRIPTION
Currently the Clear button is shown even if the EditText is disabled, and user is able to tap on clear button to clear the field when the EditText is disabled. I changed it so that if EditText is disabled, the clear button will not be shown and cannot be tapped