### PR TITLE
Typefaces are now cached

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -485,7 +485,7 @@ public class MaterialEditText extends AppCompatEditText {
   }
 
   private Typeface getCustomTypeface(@NonNull String fontPath) {
-    return Typeface.createFromAsset(getContext().getAssets(), fontPath);
+    return TypefaceCache.get(fontPath, getContext().getAssets());
   }
 
   public void setIconLeft(@DrawableRes int res) {

--- a/library/src/main/java/com/rengwuxian/materialedittext/TypefaceCache.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/TypefaceCache.java
@@ -1,0 +1,20 @@
+package com.rengwuxian.materialedittext;
+
+import android.content.res.AssetManager;
+import android.graphics.Typeface;
+
+import java.util.Hashtable;
+
+public class TypefaceCache {
+  private static final Hashtable<String, Typeface> FONT_CACHE = new Hashtable<>();
+
+  public static Typeface get(String name, AssetManager assets) {
+    synchronized (FONT_CACHE) {
+      if (!FONT_CACHE.containsKey(name)) {
+        FONT_CACHE.put(name, Typeface.createFromAsset(assets, name));
+      }
+
+      return FONT_CACHE.get(name);
+    }
+  }
+}


### PR DESCRIPTION
Critically improves layout loading speed when multiple instances of MaterialEditText with custom typefaces is used.