### PR TITLE
Added some attributes for further customization when the edittext is disabled.

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -149,6 +149,11 @@ public class MaterialEditText extends AppCompatEditText {
   private int errorColor;
 
   /**
+   * the color for the disabled dotted underline.
+   */
+  private int disabledUnderlineColor;
+
+  /**
    * min characters count limit. 0 means no limit. default is 0. NOTE: the character counter will increase the View's height.
    */
   private int minCharacters;
@@ -304,6 +309,7 @@ public class MaterialEditText extends AppCompatEditText {
   private ColorStateList textColorStateList;
   private ColorStateList textColorHintStateList;
   private ArgbEvaluator focusEvaluator = new ArgbEvaluator();
+  private boolean dottedBottomLinesForDisabledState;
   Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
   TextPaint textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
   StaticLayout textLayout;
@@ -378,8 +384,10 @@ public class MaterialEditText extends AppCompatEditText {
     primaryColor = typedArray.getColor(R.styleable.MaterialEditText_met_primaryColor, defaultPrimaryColor);
     setFloatingLabelInternal(typedArray.getInt(R.styleable.MaterialEditText_met_floatingLabel, 0));
     errorColor = typedArray.getColor(R.styleable.MaterialEditText_met_errorColor, Color.parseColor("#e7492E"));
+    disabledUnderlineColor = typedArray.getColor(R.styleable.MaterialEditText_met_disabledBottomLineColor, -1);
     minCharacters = typedArray.getInt(R.styleable.MaterialEditText_met_minCharacters, 0);
     maxCharacters = typedArray.getInt(R.styleable.MaterialEditText_met_maxCharacters, 0);
+    dottedBottomLinesForDisabledState = typedArray.getBoolean(R.styleable.MaterialEditText_met_disabledBottomLineDotted, true);
     singleLineEllipsis = typedArray.getBoolean(R.styleable.MaterialEditText_met_singleLineEllipsis, false);
     helperText = typedArray.getString(R.styleable.MaterialEditText_met_helperText);
     helperTextColor = typedArray.getColor(R.styleable.MaterialEditText_met_helperTextColor, -1);
@@ -1316,11 +1324,21 @@ public class MaterialEditText extends AppCompatEditText {
         paint.setColor(errorColor);
         canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(2), paint);
       } else if (!isEnabled()) { // disabled
-        paint.setColor(underlineColor != -1 ? underlineColor : baseColor & 0x00ffffff | 0x44000000);
-        float interval = getPixel(1);
-        for (float xOffset = 0; xOffset < getWidth(); xOffset += interval * 3) {
-          canvas.drawRect(startX + xOffset, lineStartY, startX + xOffset + interval, lineStartY + getPixel(1), paint);
+        int disabledLineColor = disabledUnderlineColor;
+        if (disabledUnderlineColor == -1){
+          disabledLineColor = underlineColor != -1 ? underlineColor : baseColor;
         }
+        paint.setColor(disabledLineColor & 0x00ffffff | 0x44000000);
+        if (dottedBottomLinesForDisabledState){
+          float interval = getPixel(1);
+          for (float xOffset = 0; xOffset < getWidth(); xOffset += interval * 3) {
+            canvas.drawRect(startX + xOffset, lineStartY, startX + xOffset + interval, lineStartY + getPixel(1), paint);
+          }
+        }
+        else{
+          canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(1), paint);
+        }
+
       } else if (hasFocus()) { // focused
         paint.setColor(primaryColor);
         canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(2), paint);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -17,6 +17,10 @@
     <attr name="met_minCharacters" format="integer" />
     <!-- max Characters count limit. 0 means no limit. -->
     <attr name="met_maxCharacters" format="integer" />
+    <!-- If disabled, then the bottom line is dotted if true.  Defaults to true. -->
+    <attr name="met_disabledBottomLineDotted" format="boolean" />
+    <!-- The color for when something is wrong.(e.g. exceeding max characters) -->
+    <attr name="met_disabledBottomLineColor" format="color" />
     <!-- Whether to show the bottom ellipsis in singleLine mode -->
     <attr name="met_singleLineEllipsis" format="boolean" />
     <!-- Reserved bottom text lines count, no matter if there is some helper/error text. -->

--- a/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
+++ b/sample/src/main/java/com/rengwuxian/materialedittext/sample/MainActivity.java
@@ -24,6 +24,8 @@ public class MainActivity extends AppCompatActivity {
 		initSingleLineEllipsisEt();
 		initSetErrorEt();
 		initValidationEt();
+
+		findViewById(R.id.disabledSolidLine).setEnabled(false);
   }
 
 	private void initEnableBt() {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -429,6 +429,15 @@
         app:met_iconPadding="0dp"
         app:met_maxCharacters="5" />
 
+      <com.rengwuxian.materialedittext.MaterialEditText
+          android:id="@+id/disabledSolidLine"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="Solid line disabled color"
+          android:text="This is disabled and still shows a solid line."
+          app:met_disabledBottomLineColor="#33ff0000"
+          app:met_disabledBottomLineDotted="false"/>
+
     </LinearLayout>
   </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Added these attributes:
- met_disabledBottomLineColor allows the user to specify a color for the
disabled underline for the edit text.
- met_disabledBottomLineDotted allows the user to turn off the dotted
line functionality when the edit text is disabled.

I also added an example to the sample project.