### PR TITLE
Change default value of some colors from -1 to Integer.MAX_VALUE

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
@@ -13,6 +13,7 @@ import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
@@ -86,7 +87,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * the floating label's text color.
    */
-  private int floatingLabelTextColor;
+  private @ColorInt int floatingLabelTextColor;
 
   /**
    * the bottom texts' size.
@@ -116,7 +117,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * the base color of the line and the texts. default is black.
    */
-  private int baseColor;
+  private @ColorInt int baseColor;
 
   /**
    * inner top padding
@@ -141,12 +142,12 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * the underline's highlight color, and the highlight color of the floating label if app:highlightFloatingLabel is set true in the xml. default is black(when app:darkTheme is false) or white(when app:darkTheme is true)
    */
-  private int primaryColor;
+  private @ColorInt int primaryColor;
 
   /**
    * the color for when something is wrong.(e.g. exceeding max characters)
    */
-  private int errorColor;
+  private @ColorInt int errorColor;
 
   /**
    * min characters count limit. 0 means no limit. default is 0. NOTE: the character counter will increase the View's height.
@@ -251,7 +252,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * Underline's color
    */
-  private int underlineColor;
+  private @ColorInt int underlineColor;
 
   /**
    * Whether to validate as soon as the text has changed. False by default
@@ -672,7 +673,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * get the color of the underline for normal state
    */
-  public int getUnderlineColor() {
+  public @ColorInt int getUnderlineColor() {
     return underlineColor;
   }
 
@@ -680,7 +681,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
    * Set the color of the underline for normal state
    * @param color
    */
-  public void setUnderlineColor(int color) {
+  public void setUnderlineColor(@ColorInt int color) {
     this.underlineColor = color;
     postInvalidate();
   }
@@ -710,11 +711,11 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     initPadding();
   }
 
-  public int getFloatingLabelTextColor() {
+  public @ColorInt int getFloatingLabelTextColor() {
     return floatingLabelTextColor;
   }
 
-  public void setFloatingLabelTextColor(int color) {
+  public void setFloatingLabelTextColor(@ColorInt int color) {
     this.floatingLabelTextColor = color;
     postInvalidate();
   }
@@ -914,7 +915,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     this.validateOnFocusLost = validate;
   }
 
-  public void setBaseColor(int color) {
+  public void setBaseColor(@ColorInt int color) {
     if (baseColor != color) {
       baseColor = color;
     }
@@ -924,7 +925,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     postInvalidate();
   }
 
-  public void setPrimaryColor(int color) {
+  public void setPrimaryColor(@ColorInt int color) {
     primaryColor = color;
     postInvalidate();
   }
@@ -932,7 +933,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * Same function as {@link #setTextColor(int)}. (Directly overriding the built-in one could cause some error, so use this method instead.)
    */
-  public void setMetTextColor(int color) {
+  public void setMetTextColor(@ColorInt int color) {
     textColorStateList = ColorStateList.valueOf(color);
     resetTextColor();
   }
@@ -945,7 +946,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     resetTextColor();
   }
 
-  private void resetTextColor() {
+  private @ColorInt void resetTextColor() {
     if (textColorStateList == null) {
       textColorStateList = new ColorStateList(new int[][]{new int[]{android.R.attr.state_enabled}, EMPTY_STATE_SET}, new int[]{baseColor & 0x00ffffff | 0xdf000000, baseColor & 0x00ffffff | 0x44000000});
       setTextColor(textColorStateList);
@@ -957,7 +958,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * Same function as {@link #setHintTextColor(int)}. (The built-in one is a final method that can't be overridden, so use this method instead.)
    */
-  public void setMetHintTextColor(int color) {
+  public void setMetHintTextColor(@ColorInt int color) {
     textColorHintStateList = ColorStateList.valueOf(color);
     resetHintTextColor();
   }
@@ -970,7 +971,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     resetHintTextColor();
   }
 
-  private void resetHintTextColor() {
+  private @ColorInt void resetHintTextColor() {
     if (textColorHintStateList == null) {
       setHintTextColor(baseColor & 0x00ffffff | 0x44000000);
     } else {
@@ -1072,11 +1073,11 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     }
   }
 
-  public int getErrorColor() {
+  public @ColorInt int getErrorColor() {
     return errorColor;
   }
 
-  public void setErrorColor(int color) {
+  public void setErrorColor(@ColorInt int color) {
     errorColor = color;
     postInvalidate();
   }
@@ -1092,11 +1093,11 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     return helperText;
   }
 
-  public int getHelperTextColor() {
+  public @ColorInt int getHelperTextColor() {
     return helperTextColor;
   }
 
-  public void setHelperTextColor(int color) {
+  public void setHelperTextColor(@ColorInt int color) {
     helperTextColor = color;
     postInvalidate();
   }

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialAutoCompleteTextView.java
@@ -206,7 +206,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
   /**
    * Helper text color
    */
-  private int helperTextColor = -1;
+  private int helperTextColor = Integer.MAX_VALUE;
 
   /**
    * error text for manually invoked {@link #setError(CharSequence)}
@@ -378,7 +378,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     maxCharacters = typedArray.getInt(R.styleable.MaterialEditText_met_maxCharacters, 0);
     singleLineEllipsis = typedArray.getBoolean(R.styleable.MaterialEditText_met_singleLineEllipsis, false);
     helperText = typedArray.getString(R.styleable.MaterialEditText_met_helperText);
-    helperTextColor = typedArray.getColor(R.styleable.MaterialEditText_met_helperTextColor, -1);
+    helperTextColor = typedArray.getColor(R.styleable.MaterialEditText_met_helperTextColor, Integer.MAX_VALUE);
     minBottomTextLines = typedArray.getInt(R.styleable.MaterialEditText_met_minBottomTextLines, 0);
     String fontPathForAccent = typedArray.getString(R.styleable.MaterialEditText_met_accentTypeface);
     if (fontPathForAccent != null && !isInEditMode()) {
@@ -396,11 +396,11 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     }
     floatingLabelPadding = typedArray.getDimensionPixelSize(R.styleable.MaterialEditText_met_floatingLabelPadding, bottomSpacing);
     floatingLabelTextSize = typedArray.getDimensionPixelSize(R.styleable.MaterialEditText_met_floatingLabelTextSize, getResources().getDimensionPixelSize(R.dimen.floating_label_text_size));
-    floatingLabelTextColor = typedArray.getColor(R.styleable.MaterialEditText_met_floatingLabelTextColor, -1);
+    floatingLabelTextColor = typedArray.getColor(R.styleable.MaterialEditText_met_floatingLabelTextColor, Integer.MAX_VALUE);
     floatingLabelAnimating = typedArray.getBoolean(R.styleable.MaterialEditText_met_floatingLabelAnimating, true);
     bottomTextSize = typedArray.getDimensionPixelSize(R.styleable.MaterialEditText_met_bottomTextSize, getResources().getDimensionPixelSize(R.dimen.bottom_text_size));
     hideUnderline = typedArray.getBoolean(R.styleable.MaterialEditText_met_hideUnderline, false);
-    underlineColor = typedArray.getColor(R.styleable.MaterialEditText_met_underlineColor, -1);
+    underlineColor = typedArray.getColor(R.styleable.MaterialEditText_met_underlineColor, Integer.MAX_VALUE);
     autoValidate = typedArray.getBoolean(R.styleable.MaterialEditText_met_autoValidate, false);
     iconLeftBitmaps = generateIconBitmaps(typedArray.getResourceId(R.styleable.MaterialEditText_met_iconLeft, -1));
     iconRightBitmaps = generateIconBitmaps(typedArray.getResourceId(R.styleable.MaterialEditText_met_iconRight, -1));
@@ -1312,7 +1312,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
         paint.setColor(errorColor);
         canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(2), paint);
       } else if (!isEnabled()) { // disabled
-        paint.setColor(underlineColor != -1 ? underlineColor : baseColor & 0x00ffffff | 0x44000000);
+        paint.setColor(underlineColor != Integer.MAX_VALUE ? underlineColor : baseColor & 0x00ffffff | 0x44000000);
         float interval = getPixel(1);
         for (float xOffset = 0; xOffset < getWidth(); xOffset += interval * 3) {
           canvas.drawRect(startX + xOffset, lineStartY, startX + xOffset + interval, lineStartY + getPixel(1), paint);
@@ -1321,7 +1321,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
         paint.setColor(primaryColor);
         canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(2), paint);
       } else { // normal
-        paint.setColor(underlineColor != -1 ? underlineColor : baseColor & 0x00ffffff | 0x1E000000);
+        paint.setColor(underlineColor != Integer.MAX_VALUE ? underlineColor : baseColor & 0x00ffffff | 0x1E000000);
         canvas.drawRect(startX, lineStartY, endX, lineStartY + getPixel(1), paint);
       }
     }
@@ -1341,7 +1341,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     // draw the bottom text
     if (textLayout != null) {
       if (tempErrorText != null || ((helperTextAlwaysShown || hasFocus()) && !TextUtils.isEmpty(helperText))) { // error text or helper text
-        textPaint.setColor(tempErrorText != null ? errorColor : helperTextColor != -1 ? helperTextColor : (baseColor & 0x00ffffff | 0x44000000));
+        textPaint.setColor(tempErrorText != null ? errorColor : helperTextColor != Integer.MAX_VALUE ? helperTextColor : (baseColor & 0x00ffffff | 0x44000000));
         canvas.save();
         if (isRTL()) {
           canvas.translate(endX - textLayout.getWidth(), lineStartY + bottomSpacing - bottomTextPadding);
@@ -1357,7 +1357,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
     if (floatingLabelEnabled && !TextUtils.isEmpty(floatingLabelText)) {
       textPaint.setTextSize(floatingLabelTextSize);
       // calculate the text color
-      textPaint.setColor((Integer) focusEvaluator.evaluate(focusFraction * (isEnabled() ? 1 : 0), floatingLabelTextColor != -1 ? floatingLabelTextColor : (baseColor & 0x00ffffff | 0x44000000), primaryColor));
+      textPaint.setColor((Integer) focusEvaluator.evaluate(focusFraction * (isEnabled() ? 1 : 0), floatingLabelTextColor != Integer.MAX_VALUE ? floatingLabelTextColor : (baseColor & 0x00ffffff | 0x44000000), primaryColor));
 
       // calculate the horizontal position
       float floatingLabelWidth = textPaint.measureText(floatingLabelText.toString());
@@ -1375,7 +1375,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
       int floatingLabelStartY = (int) (innerPaddingTop + floatingLabelTextSize + floatingLabelPadding - distance * (floatingLabelAlwaysShown ? 1 : floatingLabelFraction) + getScrollY());
 
       // calculate the alpha
-      int alpha = ((int) ((floatingLabelAlwaysShown ? 1 : floatingLabelFraction) * 0xff * (0.74f * focusFraction * (isEnabled() ? 1 : 0) + 0.26f) * (floatingLabelTextColor != -1 ? 1 : Color.alpha(floatingLabelTextColor) / 256f)));
+      int alpha = ((int) ((floatingLabelAlwaysShown ? 1 : floatingLabelFraction) * 0xff * (0.74f * focusFraction * (isEnabled() ? 1 : 0) + 0.26f) * (floatingLabelTextColor != Integer.MAX_VALUE ? 1 : Color.alpha(floatingLabelTextColor) / 256f)));
       textPaint.setAlpha(alpha);
 
       // draw the floating label


### PR DESCRIPTION
Since White (0xFFFFFFFF) is in fact -1, using the default value as -1 prevents the user from setting color White for:
- helperTextColor
- floatingLabelTextColor
- underlineColor
More info: http://stackoverflow.com/questions/30430047/typedarray-getcolor-always-returning-1-in-custom-view

Also, use proper @ColorInt annotation.