### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Eclipse:
 gradle:
 
 ```groovy
-compile 'com.rengwuxian.materialedittext:library:2.1.4'
+implementation 'com.rengwuxian.materialedittext:library:2.1.4'
 ```
 
 Maven:


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.